### PR TITLE
Add attribute check for fcurves in animation data

### DIFF
--- a/scripts/explosive_anim_importer.py
+++ b/scripts/explosive_anim_importer.py
@@ -93,9 +93,10 @@ else:
             
             # Remove root motion fcurves
             if remove_root_motion:
-                for fcurve in obj.animation_data.action.fcurves:
-                    if "Motion" in fcurve.data_path and "location" in fcurve.data_path:
-                            action.fcurves.remove(fcurve)
+                if hasattr(obj.animation_data.action, 'fcurves'):
+                    for fcurve in obj.animation_data.action.fcurves:
+                        if "Motion" in fcurve.data_path and "location" in fcurve.data_path:
+                                action.fcurves.remove(fcurve)
 
         if not action:
             print(f"Warning: '{filename}' doesn't contain an animation.")


### PR DESCRIPTION
I found an edge case, specifically with 2Hand-Bow where there are no fcurves in the original animation, so the importer throws an error.

To test, run the script as is on the 2Hand-Bow directory, the first animation will come in and nothing else.

I am on Blender 5.1.2 now, so that might be the cause of the issue.

I added a simple hasattr check to the root motion removal loop to prevent this.